### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/js/device_dialog.js
+++ b/js/device_dialog.js
@@ -1,6 +1,7 @@
 var displayMap = function() {
 	var floor = $('#floorEdit').val();
-	$('#floorPosition').html('<img src="/img/floors/' + floor + '.png">');
+	var img = $('<img>').attr('src', '/img/floors/' + floor + '.png');
+	$('#floorPosition').empty().append(img);
 };
 
 $('#deviceDialog').on('shown.bs.modal', function () {


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/home/security/code-scanning/1](https://github.com/cbulock/home/security/code-scanning/1)

To fix the issue, we need to ensure that untrusted input is not directly interpreted as HTML. Instead of using `.html()` to inject the constructed string, we can use `.text()` to safely escape the input or construct the DOM element programmatically. In this case, since the goal is to display an image, we can create the `<img>` element using jQuery or vanilla JavaScript and set its `src` attribute explicitly. This approach avoids interpreting the input as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
